### PR TITLE
adding --clean option to dump postgresql command

### DIFF
--- a/spec/Databases/PostgresqlDatabaseSpec.php
+++ b/spec/Databases/PostgresqlDatabaseSpec.php
@@ -24,7 +24,7 @@ class PostgresqlDatabaseSpec extends ObjectBehavior {
 
     function it_should_generate_a_valid_database_dump_command() {
         $this->configure();
-        $this->getDumpCommandLine('outputPath')->shouldBe("PGPASSWORD='baz' pg_dump --host='foo' --port='3306' --username='bar' 'test' -f 'outputPath'");
+        $this->getDumpCommandLine('outputPath')->shouldBe("PGPASSWORD='baz' pg_dump --clean --host='foo' --port='3306' --username='bar' 'test' -f 'outputPath'");
     }
 
     function it_should_generate_a_valid_database_restore_command() {

--- a/src/Databases/PostgresqlDatabase.php
+++ b/src/Databases/PostgresqlDatabase.php
@@ -30,7 +30,7 @@ class PostgresqlDatabase implements Database {
      * @return string
      */
     public function getDumpCommandLine($outputPath) {
-        return sprintf('PGPASSWORD=%s pg_dump --host=%s --port=%s --username=%s %s -f %s',
+        return sprintf('PGPASSWORD=%s pg_dump --clean --host=%s --port=%s --username=%s %s -f %s',
             escapeshellarg($this->config['pass']),
             escapeshellarg($this->config['host']),
             escapeshellarg($this->config['port']),


### PR DESCRIPTION
if clean option used when dumping database, so when restoring dump file, it drop existing and create database before actually restoring data.